### PR TITLE
ATSPM empty dataframes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atspm-report"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="Shawn Strasser", email="shawn.strasser@odot.oregon.gov" },
 ]

--- a/src/atspm_report/__init__.py
+++ b/src/atspm_report/__init__.py
@@ -6,5 +6,5 @@ pd.set_option('future.no_silent_downcasting', True)
 
 from .generator import ReportGenerator
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __all__ = ["ReportGenerator"]

--- a/src/atspm_report/visualization.py
+++ b/src/atspm_report/visualization.py
@@ -20,6 +20,10 @@ def create_device_plots(df_daily: 'pd.DataFrame', signals_df: 'pd.DataFrame', nu
     Returns:
         List of tuples containing (matplotlib figure, region)
     """
+    # No daily alert rows means there is nothing to visualize for this alert type.
+    if df_daily is None or df_daily.empty:
+        return []
+
     # Set larger font sizes for better readability
     plt.rcParams.update({
         'font.size': 12,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -234,6 +234,29 @@ class TestReportGenerator(unittest.TestCase):
             "Expected no PDF reports when no alerts are generated"
         )
 
+    def test_5_empty_terminations_do_not_crash_report_generation(self):
+        """Regression: empty terminations input should not crash visualization."""
+        generator = ReportGenerator({
+            **self.config,
+            "verbosity": 0,
+            "suppress_repeated_alerts": False,
+        })
+
+        empty_terminations = self.terminations.iloc[0:0].copy()
+
+        result = generator.generate(
+            signals=self.subset_signals,
+            terminations=empty_terminations,
+            detector_health=self.detector_health,
+            has_data=self.has_data,
+        )
+
+        self.assertTrue(
+            result['alerts']['maxout'].empty,
+            "Expected maxout alerts to be empty when terminations has no rows"
+        )
+        self.assertIn('reports', result)
+
 
 class TestPackageMetadata(unittest.TestCase):
     """Test package metadata and configuration."""


### PR DESCRIPTION
Fixes "Unknown data format in DataFrame" error when `atspm-report`'s visualization layer receives empty DataFrames.

The `create_device_plots` function now gracefully handles empty input DataFrames by returning an empty list of figures, preventing a `ValueError` when no data is available for a specific alert type. A regression test has been added to confirm this behavior, and the package version is bumped to 0.2.2.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-426e505e-171b-4a95-96c9-5855d961f49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-426e505e-171b-4a95-96c9-5855d961f49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard in the visualization layer plus a regression test and version bump; behavior only changes for empty inputs.
> 
> **Overview**
> Prevents `create_device_plots` from raising `ValueError("Unknown data format in DataFrame")` when an alert type has no rows by short-circuiting on `None`/empty `df_daily` and returning no figures.
> 
> Adds a regression test to ensure report generation succeeds when `terminations` is empty (maxout alerts empty and `reports` key still present), and bumps the package version to `0.2.2` in both `pyproject.toml` and `__init__.__version__`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c4ec313f4aca336fcb4c2fb9995d64aa805693f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->